### PR TITLE
refactor: Update Cuid and ValueObject classes

### DIFF
--- a/src/common/domain/cuid.vo.ts
+++ b/src/common/domain/cuid.vo.ts
@@ -1,9 +1,11 @@
 import { createId } from '@paralleldrive/cuid2';
 import { ValueObject } from './value-object';
 
-export class Cuid extends ValueObject<string> {
+export class Cuid extends ValueObject {
+  readonly id: string;
   constructor(id?: string) {
-    super(id || createId());
+    super();
+    this.id = id ?? createId();
   }
 }
 

--- a/src/common/domain/value-object.ts
+++ b/src/common/domain/value-object.ts
@@ -1,61 +1,18 @@
 import isEqual from 'lodash/isEqual';
 
-export abstract class ValueObject<Value = any> {
-  protected readonly _value: Value;
+export abstract class ValueObject {
 
-  constructor(value: Value) {
-    this._value = deepFreeze(value);
-  }
-
-  get value(): Value {
-    return this._value;
-  }
-
-  public equals(obj: this): boolean {
-    if (obj === null || obj === undefined) {
+  public equals(vo: this): boolean {
+    if (vo === null || vo === undefined) {
       return false;
     }
 
-    if (obj.value === undefined) {
+    if (vo.constructor.name !== this.constructor.name) {
       return false;
     }
 
-    if (obj.constructor.name !== this.constructor.name) {
-      return false;
-    }
-
-    return isEqual(this.value, obj.value);
+    return isEqual(vo, this);
   }
 
-  toString = () => {
-    if (typeof this.value !== 'object' || this.value === null) {
-      try {
-        return this.value!.toString();
-      } catch (e) {
-        return this.value + '';
-      }
-    }
-    const valueStr = this.value.toString();
-    return valueStr === '[object Object]'
-      ? JSON.stringify(this.value)
-      : valueStr;
-  };
-}
-
-export function deepFreeze<T>(obj: T) {
-  try {
-    const propNames = Object.getOwnPropertyNames(obj);
-
-    for (const name of propNames) {
-      const value = obj[name as keyof T];
-
-      if (value && typeof value === 'object') {
-        deepFreeze(value);
-      }
-    }
-
-    return Object.freeze(obj);
-  } catch (e) {
-    return obj;
-  }
+  toString = (): string => JSON.stringify(this);
 }

--- a/src/lectures/domain/entities/period.vo.ts
+++ b/src/lectures/domain/entities/period.vo.ts
@@ -5,20 +5,19 @@ export type PeriodProps = {
   end?: Date;
 };
 
-export class Period extends ValueObject<PeriodProps> {
+export class Period extends ValueObject {
+
+  readonly start: Date;
+  readonly end: Date | null;
+
+
   constructor(props: PeriodProps) {
-    super(props);
-  }
-
-  get start(): Date {
-    return this.value.start;
-  }
-
-  get end(): Date | undefined {
-    return this.value.end;
+    super();
+    this.start = props.start;
+    this.end = props.end ?? null;
   }
 
   setEndDate(newEndDate: Date): Period {
-    return new Period({ ...this.value, end: newEndDate });
+    return new Period({ start: this.start, end: newEndDate });
   }
 }

--- a/src/lectures/infra/db/schema-types/lecture-id.schema-type.ts
+++ b/src/lectures/infra/db/schema-types/lecture-id.schema-type.ts
@@ -7,7 +7,7 @@ export class LectureIdSchemaType extends Type<LectureId, string> {
     platform: Platform,
   ): string {
     return valueObject instanceof LectureId
-      ? valueObject.value
+      ? valueObject.id
       : (valueObject as unknown as string);
   }
 

--- a/src/lectures/infra/db/schema-types/professor-id.schema-type.ts
+++ b/src/lectures/infra/db/schema-types/professor-id.schema-type.ts
@@ -7,7 +7,7 @@ export class ProfessorIdSchemaType extends Type<ProfessorId, string> {
     platform: Platform,
   ): string {
     return valueObject instanceof ProfessorId
-      ? valueObject.value
+      ? valueObject.id
       : (valueObject as unknown as string);
   }
 

--- a/src/lectures/infra/db/schemas.ts
+++ b/src/lectures/infra/db/schemas.ts
@@ -28,16 +28,16 @@ export const LectureSchema = new EntitySchema<Lecture>({
       primary: true,
     },
     title: { type: 'varchar(255)' },
-    // period: {
-    //   kind: 'embedded',
-    //   entity: 'Period',
-    //   nullable: true,
-    //   prefix: 'period_',
-    // },
     period: {
-      type: 'json',
+      kind: 'embedded',
+      entity: 'Period',
       nullable: true,
+      prefix: 'period_',
     },
+    // period: {
+    //   type: 'json',
+    //   nullable: true,
+    // },
     professorId: {
       kind: 'm:1',
       name: 'professor_id',

--- a/tests/schemas.spec.ts
+++ b/tests/schemas.spec.ts
@@ -48,6 +48,7 @@ describe('Schemas Unit Tests', () => {
 
     const updatedLecture = await em.findOne(Lecture, { id: lecture.id });
     console.log('retrieved after start', updatedLecture);
-    expect(updatedLecture?.period).toEqual(insertedLecture?.period);
+    expect(updatedLecture?.period?.start).toEqual(insertedLecture?.period.start);
+    expect(updatedLecture?.period?.end).toEqual(insertedLecture?.period.end);
   });
 });


### PR DESCRIPTION
- Update Cuid class to use a readonly property for the id instead of extending ValueObject<string>
- Update ValueObject class to remove the generic type parameter and simplify the equals and toString methods